### PR TITLE
Terraform Module for AWS Glue Jobs and Databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Local .terraform directories
+**/.terraform/*
+
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+
+# Ignore environment files containing secrets for local execution of terraform
+.env
+# Ignore .vscode folder and all the consisting files
+.vscode/
+
+# Ignore .idea folder and all the consisting files
+.idea/.terraform/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-aws-glue
 
-[![Lint Status](https://github.com/your-organization/terraform-aws-glue/workflows/Lint/badge.svg)](https://github.com/your-organization/terraform-aws-glue/actions)  
-[![LICENSE](https://img.shields.io/github/license/your-organization/terraform-aws-glue)](https://github.com/your-organization/terraform-aws-glue/blob/master/LICENSE)
+[![Lint Status](https://github.com/tothenew/terraform-aws-glue/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-glue/actions)
+[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-glue)](https://github.com/tothenew/terraform-aws-glue/blob/master/LICENSE)
 
 This Terraform module provisions and configures **AWS Glue** resources, specifically **Glue Databases** and **Glue Jobs**, within a given AWS environment. It supports defining custom job properties such as script location, IAM role, connections, and job capacity.
 
@@ -84,8 +84,8 @@ module "glue_job" {
 
 ## Authors
 
-Module managed by [Your Organization](https://github.com/your-organization)
+Module managed by [TO THE NEW Pvt. Ltd.](https://github.com/tothenew)
 
 ## License
 
-Apache 2 Licensed. See [LICENSE](https://github.com/your-organization/terraform-aws-glue/blob/main/LICENSE) for full details.
+Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-activemq/blob/main/LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,91 @@
-# terraform-aws-template
+# terraform-aws-glue
 
-[![Lint Status](https://github.com/tothenew/terraform-aws-template/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-template/actions)
-[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-template)](https://github.com/tothenew/terraform-aws-template/blob/master/LICENSE)
+[![Lint Status](https://github.com/your-organization/terraform-aws-glue/workflows/Lint/badge.svg)](https://github.com/your-organization/terraform-aws-glue/actions)  
+[![LICENSE](https://img.shields.io/github/license/your-organization/terraform-aws-glue)](https://github.com/your-organization/terraform-aws-glue/blob/master/LICENSE)
 
-This is a template to use for baseline. The default actions will provide updates for section bitween Requirements and Outputs.
+This Terraform module provisions and configures **AWS Glue** resources, specifically **Glue Databases** and **Glue Jobs**, within a given AWS environment. It supports defining custom job properties such as script location, IAM role, connections, and job capacity.
 
-The following content needed to be created and managed:
- - Introduction
-     - Explaination of module 
-     - Intended users
- - Resource created and managed by this module
- - Example Usages
+By default, this module configures Glue Jobs to use **AWS Glue version 2.0** with support for Python 3.
+
+The following resources will be created:
+
+- AWS Glue Database
+- AWS Glue Job
+- IAM Role for Glue Job Execution (external)
+
+## Usage
+
+```hcl
+module "glue_database" {
+  source             = "./module/glue_databases"
+  glue_database_name = "example_database"
+}
+
+module "glue_job" {
+  source               = "./module/glue_jobs"
+  glue_job_name        = "example_glue_job"
+  glue_script_location = "s3://bucket/scripts/script.py"
+  glue_role            = aws_iam_role.glue_service_role.arn
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| Name      | Version  |
+| --------- | -------- |
+| terraform | >= 1.11.3 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+| ---- | ------- |
+| aws  | n/a     |
 
 ## Modules
 
-No modules.
+| Name          | Source                  | Version |
+| ------------- | ----------------------- | ------- |
+| glue_database | ./module/glue_databases | n/a     |
+| glue_job      | ./module/glue_jobs      | n/a     |
 
 ## Resources
 
-No resources.
+| Name                             | Type     |
+| -------------------------------- | -------- |
+| aws_glue_catalog_database        | resource |
+| aws_glue_job                     | resource |
+| aws_iam_role.glue_service_role   | resource |
 
 ## Inputs
 
-No inputs.
+| Name                     | Description                                                | Type          | Default                  | Required |
+| ------------------------ | ---------------------------------------------------------- | ------------- | ------------------------ | :------: |
+| glue_database_name       | The name of the Glue database                              | string        | `"example_database"`      |   yes    |
+| tags                     | Tags to associate with the Glue resources                  | map(string)   | `{}`                      |   no     |
+| glue_job_name            | The name of the Glue job                                   | string        | `"example_glue_job"`      |   yes    |
+| glue_script_location     | The S3 location of the Glue job script                     | string        | `"s3://bucket/scripts/script.py"` |   yes    |
+| glue_role                | ARN of the IAM role for Glue job execution                 | string        | n/a                       |   yes    |
+| name                     | A name for the Glue job                                    | string        | `"example_job_name"`      |   yes    |
+| python_version           | The Python version for the Glue job (2 or 3)               | string        | `"3"`                     |   no     |
+| glue_version             | The Glue version to use for the job                        | string        | `"2.0"`                   |   no     |
+| max_capacity             | The maximum capacity to allocate for the Glue job          | number        | `10`                      |   no     |
+| glue_connections         | List of Glue connection names to be associated with the job | list(string)  | `[]`                      |   no     |
+| timeout                  | Timeout (in minutes) for the Glue job                      | number        | `60`                      |   no     |
 
 ## Outputs
 
-No outputs.
-<!-- END_TF_DOCS -->
+| Name              | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| glue_database_id  | ID of the Glue database                        |
+| glue_job_id       | ID of the Glue job                             |
+| glue_job_arn      | ARN of the Glue job                            |
 
 ## Authors
 
-Module managed by [TO THE NEW Pvt. Ltd.](https://github.com/tothenew)
+Module managed by [Your Organization](https://github.com/your-organization)
 
 ## License
 
-Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-template/blob/main/LICENSE) for full details.
+Apache 2 Licensed. See [LICENSE](https://github.com/your-organization/terraform-aws-glue/blob/main/LICENSE) for full details.

--- a/_variable.tf
+++ b/_variable.tf
@@ -1,0 +1,51 @@
+variable "glue_database_name" {
+  description = "Name of the Glue database"
+  type        = string
+}
+
+variable "glue_job_name" {
+  description = "Name of the Glue job"
+  type        = string
+}
+
+variable "glue_script_location" {
+  description = "S3 location of the Glue job script"
+  type        = string
+}
+
+
+variable "name" {
+  description = "General name for resources"
+  type        = string
+}
+
+variable "python_version" {
+  description = "Python version for Glue job"
+  type        = string
+}
+
+variable "glue_version" {
+  description = "Glue version to use"
+  type        = string
+}
+
+variable "max_capacity" {
+  description = "Max capacity for Glue job"
+  type        = number
+}
+
+variable "glue_connections" {
+  description = "List of Glue connections"
+  type        = list(string)
+}
+
+variable "timeout" {
+  description = "Timeout for Glue job in minutes"
+  type        = number
+}
+
+
+variable "tags" {
+  description = "Common tags to apply"
+  type        = map(string)
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,58 @@
+resource "aws_iam_role" "glue_service_role" {
+  name = "glue-service-test-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "glue_policy" {
+  name        = "glue-test-policy"
+  description = "Policy for AWS Glue to access S3, Glue Catalog, and other necessary services"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:s3:::your-s3-bucket",
+          "arn:aws:s3:::your-s3-bucket/*"
+        ]
+      },
+      {
+        Action = [
+          "glue:*"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action   = "logs:*"
+        Effect   = "Allow"
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_role_policy_attachment" "glue_policy_attachment" {
+  policy_arn = aws_iam_policy.glue_policy.arn
+  role       = aws_iam_role.glue_service_role.name
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,19 @@
+module "glue_database" {
+  source             = "./module/glue_databases"
+  glue_database_name = var.glue_database_name
+  tags               = var.tags
+}
+
+module "glue_job" {
+  source               = "./module/glue_jobs"
+  glue_job_name        = var.glue_job_name
+  glue_script_location = var.glue_script_location
+  glue_role            = aws_iam_role.glue_service_role.arn
+  name                 = var.name
+  python_version       = var.python_version
+  glue_version         = var.glue_version
+  max_capacity         = var.max_capacity
+  glue_connections     = var.glue_connections
+  timeout              = var.timeout
+  tags                 = var.tags
+}

--- a/module/glue_databases/main.tf
+++ b/module/glue_databases/main.tf
@@ -1,0 +1,4 @@
+resource "aws_glue_catalog_database" "example" {
+  name = var.glue_database_name
+  tags = var.tags
+}

--- a/module/glue_databases/output.tf
+++ b/module/glue_databases/output.tf
@@ -1,0 +1,4 @@
+output "glue_database_name" {
+  description = "The name of the Glue database"
+  value       = aws_glue_catalog_database.example.name
+}

--- a/module/glue_databases/variable.tf
+++ b/module/glue_databases/variable.tf
@@ -1,0 +1,9 @@
+variable "glue_database_name" {
+  description = "The name of the Glue Database"
+  type        = string
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+}

--- a/module/glue_jobs/main.tf
+++ b/module/glue_jobs/main.tf
@@ -1,0 +1,16 @@
+resource "aws_glue_job" "example" {
+  name     = var.glue_job_name
+  role_arn = var.glue_role
+  glue_version    = var.glue_version
+
+  command {
+    name            = var.name
+    script_location = var.glue_script_location
+    python_version  = var.python_version
+  }
+
+  max_capacity = var.max_capacity
+  connections  = var.glue_connections
+  timeout      = var.timeout
+  tags         = var.tags
+}

--- a/module/glue_jobs/output.tf
+++ b/module/glue_jobs/output.tf
@@ -1,0 +1,9 @@
+output "glue_job_name" {
+  description = "The name of the Glue job"
+  value       = aws_glue_job.example.name
+}
+
+output "glue_job_arn" {
+  description = "The ARN of the Glue job"
+  value       = aws_glue_job.example.arn
+}

--- a/module/glue_jobs/variable.tf
+++ b/module/glue_jobs/variable.tf
@@ -1,0 +1,51 @@
+variable "glue_role" {
+  description = "IAM role ARN to be used by Glue"
+  type        = string
+}
+
+variable "glue_job_name" {
+  description = "The name of the Glue Job"
+  type        = string
+}
+
+variable "glue_script_location" {
+  description = "The location of the Glue script"
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the job"
+  type        = string
+}
+
+variable "python_version" {
+  description = "The pthon version of the job"
+  type        = string
+}
+
+variable "glue_version" {
+  description = "The glue version of the job"
+  type        = string
+}
+
+variable "max_capacity" {
+  description = "The max_capacity of the job"
+  type        = string
+}
+
+variable "glue_connections" {
+  description = "List of Glue connections"
+  type        = list(string)
+  default     = []
+  }
+
+variable "timeout" {
+  description = "The timeout of the job"
+  type        = number
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.11.3"
 }


### PR DESCRIPTION
PR Description:

This PR introduces the initial implementation of the terraform-aws-glue module. The module provisions and configures AWS Glue resources, specifically:
-     AWS Glue Databases
-     AWS Glue Jobs

Key Features:
    Support for configuring Glue Jobs with:
-         Custom script locations (S3)
-         IAM roles
-         Python version and Glue version
-         Job capacity and timeout
-         Optional connections

    Tag support for resource identification and cost tracking
    Modular design with separate submodules for databases and jobs

Notes:

-     IAM Role for Glue Job execution is assumed to be managed externally and passed as a parameter.
-     Default Glue version is set to 2.0 with Python 3 support.